### PR TITLE
The magics are not provided by "Jupyter"

### DIFF
--- a/docs/jmatlab_use.ipynb
+++ b/docs/jmatlab_use.ipynb
@@ -413,7 +413,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Fortunately, Jupyter's \"%%file\" magic allows us to write a code cell to a file."
+    "Fortunately, the [Matlab kernel's](https://github.com/Calysto/matlab_kernel/) \"%%file\" magic allows us to write a code cell to a file."
    ]
   },
   {


### PR DESCRIPTION
Although the text simplifies credit, the Matlab kernel is not written by the Jupyter project, but by the Calysto team. Would be nice to give credit for this somewhere. Thanks!