### PR TITLE
Fixed typo in kernal

### DIFF
--- a/docs/jmatlab_install.ipynb
+++ b/docs/jmatlab_install.ipynb
@@ -74,7 +74,7 @@
     "\n",
     "Then, install the [Matlab kernel for Jupyter](https://github.com/Calysto/matlab_kernel).\n",
     "\n",
-    "    pip install matlab_kernal\n",
+    "    pip install matlab_kernel\n",
     "\n",
     "    python -m matlab_kernel install\n",
     "\n",


### PR DESCRIPTION
Fixed minor typo kernal should be kernel in: 
```
pip install matlab_kernal
```