### PR TITLE
Update jmatlab_install.ipynb

### DIFF
--- a/docs/jmatlab_install.ipynb
+++ b/docs/jmatlab_install.ipynb
@@ -74,7 +74,7 @@
     "\n",
     "Then, install the [Matlab kernel for Jupyter](https://github.com/Calysto/matlab_kernel).\n",
     "\n",
-    "    pip install matlab_kernal\n",
+    "    pip install matlab_kernel\n",
     "\n",
     "    python -m matlab_kernel install\n",
     "\n",


### PR DESCRIPTION
There is a typo: "pip install matlab_kernal" should be "pip install matlab_kernel"